### PR TITLE
WordpRessのRSSに制御文字が入り込んでパースに失敗することがあることへの対処

### DIFF
--- a/xoops_trust_path/modules/d3pipes/class/xml.php
+++ b/xoops_trust_path/modules/d3pipes/class/xml.php
@@ -14,6 +14,8 @@
 # and returns an equivalent PHP data structure
 ###################################################################################
 function & XML_unserialize(&$xml){
+	// 制御文字を除外する
+	$xml = preg_replace('/[\x00-\x09\x0B\x0C\x0E-\x1F\x7F]/', '', $xml);
 	$xml_parser = new XML();
 	$data = &$xml_parser->parse($xml);
 	$xml_parser->destruct();

--- a/xoops_trust_path/modules/d3pipes/class/xml.php
+++ b/xoops_trust_path/modules/d3pipes/class/xml.php
@@ -14,7 +14,7 @@
 # and returns an equivalent PHP data structure
 ###################################################################################
 function & XML_unserialize(&$xml){
-	// 制御文字を除外する
+	// remove control characters
 	$xml = preg_replace('/[\x00-\x09\x0B\x0C\x0E-\x1F\x7F]/', '', $xml);
 	$xml_parser = new XML();
 	$data = &$xml_parser->parse($xml);


### PR DESCRIPTION
WordpRessのRSSに制御文字が入り込んでパースに失敗することがあることへの対処https://www.facebook.com/groups/xoops.creators/permalink/1943401732366889/